### PR TITLE
Bumped version of jsdom (removes contextify dependency)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markserv",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "markserv serves Markdown files as GitHub style HTML and LiveReloads your files in the browser as you edit.",
   "keywords": [
     "markdown",
@@ -24,7 +24,7 @@
     "commander": "^2.5.1",
     "connect": "^3.3.3",
     "connect-livereload": "^0.5.3",
-    "jsdom": "^2.0.0",
+    "jsdom": "^8.0.0",
     "less": "^2.4.0",
     "livereload": "^0.3.6",
     "livereload-js": "^2.2.2",


### PR DESCRIPTION
When I tried to use this on a Windows machine it failed due to the transitive `contextify` dependency which is brought in by the older version of `jsdom`. 

`contextify` is a pretty ugly dependency since it requires a full development environment setup on Windows at least (e.g. Visual Studio, etc) and has since been folded in to the core node version itself.

The only downside of this is that now a later version of `node` is required (`> 4`) than was before but it makes building/using significantly easier (and staying up to date is useful in itself).