### PR TITLE
'Use strict' -> 'use strict'

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-'Use strict';
+'use strict';
 
 // Markdown Extension Types
 const markdownExtensions = [


### PR DESCRIPTION
I don't think `use strict` can be capitalized since it's a flag. This works great when I change it.