### PR TITLE
Mathjax Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ I purchased [Marked2](http://marked2app.com/) after seeing a colleage use it to 
  - Markdown rendered with GitHub style syntax highlighting
  - LiveReload updates the view when your files change
  - Links to external Markdown files are re-written and followed by the server
+ - MathJax equations ([example](examples/mathjax.md))
 
 ## Installing
 

--- a/examples/mathjax.md
+++ b/examples/mathjax.md
@@ -1,0 +1,5 @@
+# Syntax Highlighting Example
+
+This is an inline MathJax expression $e=mc^2$. The below is a standalone one:
+
+$$ \sum_{i=1}^{100}{i} = 1050 $$

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markserv",
-  "version": "0.0.26",
+  "version": "0.1.0",
   "description": "markserv serves Markdown files as GitHub style HTML and LiveReloads your files in the browser as you edit.",
   "keywords": [
     "markdown",

--- a/server.js
+++ b/server.js
@@ -239,6 +239,14 @@ const buildHTMLFromMarkDown = markdownPath => new Promise(resolve => {
             <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
             <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
             <link rel="stylesheet" href="https://highlightjs.org/static/demo/styles/github-gist.css">
+            <script type="text/x-mathjax-config">
+            MathJax.Hub.Config({
+              tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+            });
+            </script>
+            <script type="text/javascript" async
+              src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
+            </script>
           </head>
           <body>
             <article class="markdown-body">${htmlBody}</article>
@@ -255,6 +263,14 @@ const buildHTMLFromMarkDown = markdownPath => new Promise(resolve => {
             <link rel="stylesheet" href="https://highlightjs.org/static/demo/styles/github-gist.css">
             <meta charset="utf-8">
             <style>${css}</style>
+            <script type="text/x-mathjax-config">
+            MathJax.Hub.Config({
+              tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+            });
+            </script>
+            <script type="text/javascript" async
+              src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
+            </script>
           </head>
           <body>
             <div class="container">


### PR DESCRIPTION
Tested Mathjax support from @kflu 's PR (https://github.com/F1LT3R/markserv/pull/12)

Looks good.

Updating `version` in `package.json`.