### PR TITLE
MathJax: do not render content in parenthesis

### DIFF
--- a/server.js
+++ b/server.js
@@ -241,7 +241,7 @@ const buildHTMLFromMarkDown = markdownPath => new Promise(resolve => {
             <link rel="stylesheet" href="https://highlightjs.org/static/demo/styles/github-gist.css">
             <script type="text/x-mathjax-config">
             MathJax.Hub.Config({
-              tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+              tex2jax: {inlineMath: [['$','$']]}
             });
             </script>
             <script type="text/javascript" async
@@ -265,7 +265,7 @@ const buildHTMLFromMarkDown = markdownPath => new Promise(resolve => {
             <style>${css}</style>
             <script type="text/x-mathjax-config">
             MathJax.Hub.Config({
-              tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+              tex2jax: {inlineMath: [['$','$']]}
             });
             </script>
             <script type="text/javascript" async

--- a/server.js
+++ b/server.js
@@ -240,13 +240,13 @@ const buildHTMLFromMarkDown = markdownPath => new Promise(resolve => {
             <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
             <link rel="stylesheet" href="https://highlightjs.org/static/demo/styles/github-gist.css">
             <script type="text/x-mathjax-config">
-            MathJax.Hub.Config({
-              tex2jax: {inlineMath: [['$','$']]}
-            });
-            </script>
-            <script type="text/javascript" async
-              src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
-            </script>
+MathJax.Hub.Config({
+  tex2jax: {inlineMath: [['$','$']]}
+});
+</script>
+<script type="text/javascript" async
+  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
+</script>
           </head>
           <body>
             <article class="markdown-body">${htmlBody}</article>
@@ -264,13 +264,13 @@ const buildHTMLFromMarkDown = markdownPath => new Promise(resolve => {
             <meta charset="utf-8">
             <style>${css}</style>
             <script type="text/x-mathjax-config">
-            MathJax.Hub.Config({
-              tex2jax: {inlineMath: [['$','$']]}
-            });
-            </script>
-            <script type="text/javascript" async
-              src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
-            </script>
+MathJax.Hub.Config({
+  tex2jax: {inlineMath: [['$','$']]}
+});
+</script>
+<script type="text/javascript" async
+  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
+</script>
           </head>
           <body>
             <div class="container">
@@ -502,7 +502,7 @@ const serversActivated = () => {
 
   if (flags.file) {
     open(serveURL + '/' + flags.file);
-  } else if (flags.x === false) {
+  } else if (!flags.x) {
     open(serveURL);
   }
 };


### PR DESCRIPTION
Only allow $...$ to be processes. The previous config allows (...) to, which is too frequently used in normal text so it should be disallowed to render math equations.