### PR TITLE
Use newer version of livereload

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "jsdom": "^9.9.1",
     "less": "^2.7.2",
     "livereload": "^0.7.0",
-    "livereload-js": "^2.3.0",
     "micromatch": "^3.1.3",
     "mime": "^1.4.1",
     "open": "0.0.5",

--- a/server.js
+++ b/server.js
@@ -4,28 +4,28 @@
 
 // Markdown Extension Types
 const markdownExtensions = [
-	'.markdown',
-	'.mdown',
-	'.mkdn',
-	'.md',
-	'.mkd',
-	'.mdwn',
-	'.mdtxt',
-	'.mdtext',
-	'.text'
+	'markdown',
+	'mdown',
+	'mkdn',
+	'md',
+	'mkd',
+	'mdwn',
+	'mdtxt',
+	'mdtext',
+	'text'
 ]
 
 const watchExtensions = markdownExtensions.concat([
-	'.less',
-	'.js',
-	'.css',
-	'.html',
-	'.htm',
-	'.json',
-	'.gif',
-	'.png',
-	'.jpg',
-	'.jpeg'
+	'less',
+	'js',
+	'css',
+	'html',
+	'htm',
+	'json',
+	'gif',
+	'png',
+	'jpg',
+	'jpeg'
 ])
 
 const PORT_RANGE = {
@@ -105,7 +105,7 @@ const hasMarkdownExtension = path => {
 	let extensionMatch = false
 
 	markdownExtensions.forEach(extension => {
-		if (extension === fileExtension) {
+		if (`.${extension}` === fileExtension) {
 			extensionMatch = true
 		}
 	})
@@ -447,7 +447,7 @@ const startLiveReloadServer = () => new Promise(resolve => {
 	LIVE_RELOAD_SERVER = liveReload.createServer({
 		exts: watchExtensions,
 		port: LIVE_RELOAD_PORT
-	}).watch(flags.dir)
+	}).watch(path.resolve(flags.dir))
 
 	resolve(LIVE_RELOAD_SERVER)
 })


### PR DESCRIPTION
This upgrades to a newer version of livereload which relies on ws instead of websocket.io
This fixes #19 and #24