### PR TITLE
[Fix] More accurate width of markdown box #73

### DIFF
--- a/lib/templates/github.less
+++ b/lib/templates/github.less
@@ -1,8 +1,14 @@
 body {
-  width: 45em;
+  width: 978px;
   border: 1px solid #ddd;
   outline: 1300px solid #fff;
   margin: 16px auto;
+}
+
+@media screen and (max-width: 1024px) {
+  body {
+    width: 98%;
+  }
 }
 
 body .markdown-body

--- a/lib/templates/markserv.css
+++ b/lib/templates/markserv.css
@@ -1,10 +1,16 @@
 body {
-  width: 45em;
+  width: 978px;
   margin: 16px auto;
 }
 
 body .markdown-body {
   padding: 30px;
+}
+
+@media screen and (max-width: 1024px) {
+  body {
+    width: 98%;
+  }
 }
 
 @media screen and (min-width: 768px) {


### PR DESCRIPTION
- Box is 978px if resolution is >= 1024px
- Box is 98% if resolution is less 1024px (for responsive)

Imho that is more accurate, like github style.
Issue: #73 