### PR TITLE
put live-reload middleware above main app

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -535,12 +535,11 @@ const createRequestHandler = flags => {
 }
 
 const startConnectApp = (liveReloadPort, httpRequestHandler) => {
-	const connectApp = connect().use('/', httpRequestHandler)
-	connectApp.use(connectLiveReload({
-		port: liveReloadPort
-	}))
-
-	return connectApp
+	return connect()
+		.use(connectLiveReload({
+			port: liveReloadPort
+		}))
+		.use('/', httpRequestHandler)
 }
 
 const startHTTPServer = (connectApp, port, flags) => {


### PR DESCRIPTION
Live reload wasn't working for me. I poked around a bit and saw that the `live-reload.js` wasn't getting injected into the rendered HTML. Reading the [connect-livereload docs](https://www.npmjs.com/package/connect-livereload#use) it looks like that's because it needs to be inserted in the connect middleware stack *before* any routes that we want it to inject the live-reload.js into:

> In your connect or express application add this after the static and before the dynamic routes. If you need liveReload on static html files, then place it before the static routes

I tested this locally and it fixed things for me - live-reload wasn't working before, and is now.