### PR TITLE
Link to the correct Firefox LiveReload plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ readme
 To see real-time updates as you save your markdown files, you will need to install the LiveReload plugin for your browser:
 
 - [Chrome](https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei?hl=en)
-- [Firefox](https://addons.mozilla.org/addon/live-reload/)
+- [Firefox](https://addons.mozilla.org/addon/livereload-web-extension/)
 - [Internet Explorer](https://github.com/dvdotsenko/livereload_ie_extension)
 
 With the Live Reload plugin installed and turned on, you should see the page reloading as you save your Markdown file.


### PR DESCRIPTION
The README currently links to a rule-based autoreload Firefox plugin. This PR replaces it with the appropriate plugin for the LiveReload protocol that markserv uses.