### PR TITLE
`yarn --global` -> `yarn global` in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Supporting: [MathJax](tests/mathjax.md), [Chinese Characters](tests/测试.md), 
 $ npm i -g markserv
 
 # Yarn
-$ yarn --global add markserv
+$ yarn global add markserv
 ```
 
 <a href="https://patreon.com/bePatron?u=9720216"><img width="160" src="https://f1lt3r.io/content/images/2018/04/become_a_patron_button@2x.png"></a>

--- a/lib/server.js
+++ b/lib/server.js
@@ -656,7 +656,7 @@ const optionalUpgrade = async flags => {
 		const logInstallNotes = () => {
 			msg(chalk.bgRed('✨UPGRADE✨'), 'Upgrade cancelled. To upgrade manually:', flags)
 			msg(chalk.bgRed('✨UPGRADE✨'), chalk`{bgYellow.black.bold  npm i -g markserv@${version} }`, flags)
-			msg(chalk.bgRed('✨UPGRADE✨'), chalk`{bgYellow.black.bold  yarn --global add markserv@${version} }`, flags)
+			msg(chalk.bgRed('✨UPGRADE✨'), chalk`{bgYellow.black.bold  yarn global add markserv@${version} }`, flags)
 		}
 
 		const choice = await promptly.choose(chalk`{bgGreen.black   Markserv  } {bgRed ✨UPGRADE✨}: Do you want to upgrade automatically? (y/n)`, ['y', 'n'])


### PR DESCRIPTION
Global is a command in yarn, not a flag.  See https://yarnpkg.com/lang/en/docs/cli/global/