### PR TITLE
Add "darkmode" toggle for new dark theme overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ To list the options/flags for the markserv CLI tool:
 $ markserv --help
 ```
 
+### Using the "Darkmode" theme
+
+You can enable the dark theme by doing this:
+
+```shell
+markserv -d true
+```
+
 ### Changing the HTTP Port
 
 You can change the HTTP Port like this:

--- a/lib/cli-defs.js
+++ b/lib/cli-defs.js
@@ -23,6 +23,11 @@ module.exports = {
 		verbose: {
 			alias: 'v',
 			default: false
+		},
+
+		darkmode: {
+			alias: 'd',
+			default: false
 		}
 	}
 }

--- a/lib/cli-help.txt
+++ b/lib/cli-help.txt
@@ -9,3 +9,4 @@ Options
 	--silent, -i  Silent (false)
 	--address, -a  Serve on ip/address [address] (localhost)
 	--verbose, -v  Verbose output (false)
+	--darkmode, -d  Enable dark theme (false)

--- a/lib/server.js
+++ b/lib/server.js
@@ -461,7 +461,8 @@ const createRequestHandler = flags => {
 					const handlebarData = {
 						title: path.parse(filePath).base,
 						content: output,
-						pid: process.pid | 'N/A'
+						pid: process.pid | 'N/A',
+						darkmode: flags.darkmode
 					}
 
 					return baseTemplate(templateUrl, handlebarData).then(final => {
@@ -504,7 +505,8 @@ const createRequestHandler = flags => {
 					content: dirToHtml(filePath),
 					title: path.parse(filePath).base,
 					pid: process.pid | 'N/A',
-					breadcrumbs: createBreadcrumbs(path.relative(dir, filePath))
+					breadcrumbs: createBreadcrumbs(path.relative(dir, filePath)),
+					darkmode: flags.darkmode
 				}
 
 				return baseTemplate(templateUrl, handlebarData).then(final => {

--- a/lib/templates/darkmode.css
+++ b/lib/templates/darkmode.css
@@ -1,0 +1,41 @@
+html, body, input, textarea, select, button {
+    background-color: #181a1b;
+    border-color: #575757;
+    color: #e8e6e3;
+}
+a {
+    color: #3391ff;
+}
+table {
+    border-color: #4c4c4c;
+}
+body {
+  outline: none;
+}
+.markdown-body {
+  color: rgb(214, 211, 205);
+}
+.markdown-body hr {
+  background-color: rgb(31, 33, 34);
+  border-top-color: initial;
+  border-right-color: initial;
+  border-bottom-color: initial;
+  border-left-color: initial;
+}
+.markdown-body h1 {
+  border-bottom-color: rgb(54, 54, 54);
+}
+.markdown-body h2 {
+  border-bottom-color: rgb(54, 54, 54);
+}
+.markdown-body .highlight pre, .markdown-body pre {
+  background-color: rgb(27, 28, 29);
+}
+.markdown-body pre code {
+  background-color: transparent;
+  border-top-color: initial;
+  border-right-color: initial;
+  border-bottom-color: initial;
+  border-left-color: initial;
+  color: rgb(186, 181, 171);
+}

--- a/lib/templates/directory.html
+++ b/lib/templates/directory.html
@@ -7,6 +7,9 @@
 	<title>{{title}}</title>
 	<meta charset="utf-8">
 	<link rel="stylesheet" href="{markserv}templates/markserv.css">
+	{{#if darkmode}}
+		<link rel="stylesheet" href="{markserv}templates/darkmode.css">
+	{{/if}}
 	<link rel="stylesheet" href="{markserv}templates/highlight-js-github-gist.css">
 	<link rel="stylesheet" href="{markserv}icons/icons.css">
 </head>

--- a/lib/templates/error.html
+++ b/lib/templates/error.html
@@ -7,6 +7,9 @@
 	<title>{{code}}: {{filePath}}</title>
 	<meta charset="utf-8">
 	<link rel="stylesheet" href="{markserv}templates/markserv.css">
+	{{#if darkmode}}
+		<link rel="stylesheet" href="{markserv}templates/darkmode.css">
+	{{/if}}
 	<link rel="stylesheet" href="{markserv}templates/highlight-js-github-gist.css">
 	<link rel="stylesheet" href="{markserv}icons/icons.css">
 </head>

--- a/lib/templates/markdown.html
+++ b/lib/templates/markdown.html
@@ -7,6 +7,9 @@
 	<title>{{title}}</title>
 	<meta charset="utf-8">
 	<link rel="stylesheet" href="{markserv}templates/markserv.css">
+	{{#if darkmode}}
+		<link rel="stylesheet" href="{markserv}templates/darkmode.css">
+	{{/if}}
 	<link rel="stylesheet" href="{markserv}templates/highlight-js-github-gist.css">
 	<script type="text/javascript" id="MathJax-script" async
 	      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">


### PR DESCRIPTION
Closes #70 

This PR is ready for merge, tested with markdown files in repo and my own notes files.

**Note**
The darkmode toggle enables a CSS overlay theme, may want to make a whole new theme or use less flag in the future? Also, maybe we should make a markdown elements test page for future "themes"?