### PR TITLE
Fix livereload port and browser args

### DIFF
--- a/lib/cli-defs.js
+++ b/lib/cli-defs.js
@@ -6,7 +6,7 @@ module.exports = {
 		},
 
 		livereloadport: {
-			alias: 'b',
+			alias: 'l',
 			default: 35729
 		},
 
@@ -23,6 +23,11 @@ module.exports = {
 		verbose: {
 			alias: 'v',
 			default: false
+		},
+
+		browser: {
+			alias: 'b',
+			default: true
 		}
 	}
 }


### PR DESCRIPTION
The `-b` and `-l` options seemed to have been mis-rewritten during the migration to meow.