### PR TITLE
add ability to specify browser on command line

### DIFF
--- a/lib/cli-defs.js
+++ b/lib/cli-defs.js
@@ -6,7 +6,7 @@ module.exports = {
 		},
 
 		livereloadport: {
-			alias: 'b',
+			alias: 'l',
 			default: 35729
 		},
 
@@ -23,6 +23,11 @@ module.exports = {
 		verbose: {
 			alias: 'v',
 			default: false
-		}
+		},
+
+        browser: {
+            alias: 'b',
+            default: true
+        }
 	}
 }

--- a/lib/cli-defs.js
+++ b/lib/cli-defs.js
@@ -25,9 +25,9 @@ module.exports = {
 			default: false
 		},
 
-        browser: {
-            alias: 'b',
-            default: true
-        }
+		browser: {
+			alias: 'b',
+			default: true
+		}
 	}
 }

--- a/lib/cli-help.txt
+++ b/lib/cli-help.txt
@@ -3,9 +3,9 @@ $ markserv <file/dir>
 $ readme (serve closest README.md file)
 
 Options
-	--port, -p,  HTTP port [port] (80)
-	--livereloadport, -l  LiveReload port [port/false] (35729)
-	--browser, -b  Launch browser (true)
-	--silent, -i  Silent (false)
-	--address, -a  Serve on ip/address [address] (localhost)
-	--verbose, -v  Verbose output (false)
+    --port, -p,           HTTP port [port] (80)
+    --livereloadport, -l  LiveReload port [port/false] (35729)
+    --browser, -b         Launch browser [browser/true/false] (true)
+    --silent, -i          Silent (false)
+    --address, -a         Serve on ip/address [address] (localhost)
+    --verbose, -v         Verbose output (false)

--- a/lib/server.js
+++ b/lib/server.js
@@ -702,8 +702,16 @@ const init = async flags => {
 			return
 		}
 
-		if (launchUrl) {
-			opn(launchUrl)
+        let opts = {}
+        if (flags.browser === true ||
+            flags.browser === 'true') {
+        } else {
+            // Manually set browser if so specified
+            opts = {app: flags.browser}
+        }
+
+        if (launchUrl) {
+            opn(launchUrl, opts)
 		}
 	}
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -702,16 +702,14 @@ const init = async flags => {
 			return
 		}
 
-        let opts = {}
-        if (flags.browser === true ||
-            flags.browser === 'true') {
-        } else {
-            // Manually set browser if so specified
-            opts = {app: flags.browser}
-        }
+		// Manually set browser if so specified
+		let opts = {}
+		if (typeof flags.browser === 'string') {
+			opts = {app: flags.browser}
+		}
 
-        if (launchUrl) {
-            opn(launchUrl, opts)
+		if (launchUrl) {
+			opn(launchUrl, opts)
 		}
 	}
 


### PR DESCRIPTION
Incorporated fix in PR #101 and added ability to pass the -b option the name of the browser that is opened (default browser is used if none is specified).