### PR TITLE
Add max-width: 100% for <video> as well

### DIFF
--- a/lib/templates/markserv.css
+++ b/lib/templates/markserv.css
@@ -434,7 +434,8 @@ li.icon {
 .markdown-body table tr:nth-child(2n) {
   background-color: #f8f8f8;
 }
-.markdown-body img {
+.markdown-body img,
+.markdown-body video {
   max-width: 100%;
   -moz-box-sizing: border-box;
   box-sizing: border-box;


### PR DESCRIPTION
The same rule that makes sure that images are scaled down to the size of the article, should also apply to videos.