### PR TITLE
remove trailing forward slashes from exclusions

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -93,8 +93,8 @@ const fileTypes = {
 	],
 
 	exclusions: [
-		'node_modules/',
-		'.git/'
+		'node_modules',
+		'.git'
 	]
 }
 


### PR DESCRIPTION
The exclusions are not set correctly and as a result the contents of node_modules will not get ignored, causing a huge amount of file watchers to be created.<br>
This is because chokidar, which is used by livereload, appends string exclusions (other possible exclusions are globstrings and regular expressions) with `"/**"`. Since our exclusions are `.git/` and `node_modules/` this results in the following exclusions in chokidar: <br>
```
/path/to/project/node_modules//**
/path/to/project/.git//**
```
This pull request removes the trailing slashes so that the matching works in chokidar and the contents of the node_modules folder gets ignored.<br>
As a side note the reason .git was ignored even with this problem present is because chokidar ignores .git by default.

fixes #128 